### PR TITLE
IN-217: Allow dots '.' in usernames.

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -125,7 +125,7 @@ while read line; do
   USER_NAME="`get_user_name "$line"`"
 
   # Make sure the user name is alphanumeric
-  if [[ "$USER_NAME" =~ ^[a-z][-a-z0-9]*$ ]]; then
+  if [[ "$USER_NAME" =~ ^[a-z][-.a-z0-9]*$ ]]; then
 
     # Create a user account if it does not already exist
     cut -d: -f1 /etc/passwd | grep -qx $USER_NAME


### PR DESCRIPTION
![Screenshot 2024-10-25 at 10 56 21](https://github.com/user-attachments/assets/8f6a0ced-0f51-4885-af6b-1479bac246be)

Previously only the `kayhan.pub` key was being pulled and a user created. Now:

```
[ec2-user@ip-10-0-3-121 ~]$ ls -l /home
total 0
drwx------ 3 ec2-user     ec2-user     95 Oct 25 09:55 ec2-user
drwx------ 3 kayhan       kayhan       74 Oct 25 09:55 kayhan
drwx------ 3 kayhan.sefat kayhan.sefat 74 Oct 25 09:55 kayhan.sefat
```