### PR TITLE
IN-217: bastion_host_key_pair is now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,13 @@ No modules.
 | <a name="input_auto_scaling_group_subnets"></a> [auto\_scaling\_group\_subnets](#input\_auto\_scaling\_group\_subnets) | List of subnets where the Auto Scaling Group will deploy the instances | `list(string)` | n/a | yes |
 | <a name="input_bastion_additional_security_groups"></a> [bastion\_additional\_security\_groups](#input\_bastion\_additional\_security\_groups) | List of additional security groups to attach to the launch template | `list(string)` | `[]` | no |
 | <a name="input_bastion_ami"></a> [bastion\_ami](#input\_bastion\_ami) | The AMI that the Bastion Host will use. | `string` | `""` | no |
+| <a name="input_bastion_autoscaling_group_name"></a> [bastion\_autoscaling\_group\_name](#input\_bastion\_autoscaling\_group\_name) | Bastion Auto scaling group Name | `string` | `"ASG-bastion-lt"` | no |
 | <a name="input_bastion_host_key_pair"></a> [bastion\_host\_key\_pair](#input\_bastion\_host\_key\_pair) | Select the key pair to use to launch the bastion host | `string` | n/a | yes |
 | <a name="input_bastion_iam_permissions_boundary"></a> [bastion\_iam\_permissions\_boundary](#input\_bastion\_iam\_permissions\_boundary) | IAM Role Permissions Boundary to constrain the bastion host role | `string` | `""` | no |
 | <a name="input_bastion_iam_policy_name"></a> [bastion\_iam\_policy\_name](#input\_bastion\_iam\_policy\_name) | IAM policy name to create for granting the instance role access to the bucket | `string` | `"BastionHost"` | no |
 | <a name="input_bastion_iam_role_name"></a> [bastion\_iam\_role\_name](#input\_bastion\_iam\_role\_name) | IAM role name to create | `string` | `null` | no |
 | <a name="input_bastion_instance_count"></a> [bastion\_instance\_count](#input\_bastion\_instance\_count) | n/a | `number` | `1` | no |
-| <a name="input_bastion_launch_template_name"></a> [bastion\_launch\_template\_name](#input\_bastion\_launch\_template\_name) | Bastion Launch template Name, will also be used for the ASG | `string` | `"bastion-lt"` | no |
+| <a name="input_bastion_launch_template_name"></a> [bastion\_launch\_template\_name](#input\_bastion\_launch\_template\_name) | Bastion Launch template Name | `string` | `"bastion-lt"` | no |
 | <a name="input_bastion_record_name"></a> [bastion\_record\_name](#input\_bastion\_record\_name) | DNS record name to use for the bastion | `string` | `""` | no |
 | <a name="input_bastion_security_group_id"></a> [bastion\_security\_group\_id](#input\_bastion\_security\_group\_id) | Custom security group to use | `string` | `""` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | The bucket and all objects should be destroyed when using true | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ module "bastion" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
 
 ## Modules
 
@@ -99,10 +99,14 @@ No modules.
 | [aws_s3_bucket_versioning.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_object.bucket_public_keys_readme](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [aws_security_group.bastion_host_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.lb_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.private_instances_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.egress_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_bastion_via_lb_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.ingress_instances](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ami.amazon-linux-2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.assume_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bastion_host_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -129,9 +133,9 @@ No modules.
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | The bucket and all objects should be destroyed when using true | `bool` | `false` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name where the bastion will store the logs | `string` | n/a | yes |
 | <a name="input_bucket_versioning"></a> [bucket\_versioning](#input\_bucket\_versioning) | Enable bucket versioning or not | `bool` | `true` | no |
-| <a name="input_cidrs"></a> [cidrs](#input\_cidrs) | List of CIDRs that can access the bastion. Default: 0.0.0.0/0 | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_cidrs"></a> [cidrs](#input\_cidrs) | List of CIDRs that can access the bastion. Default: 0.0.0.0/0 | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_create_dns_record"></a> [create\_dns\_record](#input\_create\_dns\_record) | Choose if you want to create a record name for the bastion (LB). If true, 'hosted\_zone\_id' and 'bastion\_record\_name' are mandatory | `bool` | n/a | yes |
-| <a name="input_create_elb"></a> [create\_elb](#input\_create\_elb) | Choose if you want to deploy an ELB for accessing bastion hosts. Only select false if there is no need to SSH into bastion from outside. If true, you must set elb\_subnets and is\_lb\_private | `bool` | `true` | no |
+| <a name="input_create_elb"></a> [create\_elb](#input\_create\_elb) | Choose if you want to deploy an ELB for accessing bastion hosts. If true, you must set elb\_subnets and is\_lb\_private | `bool` | `true` | no |
 | <a name="input_disk_encrypt"></a> [disk\_encrypt](#input\_disk\_encrypt) | Instance EBS encryption | `bool` | `true` | no |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Root EBS size in GB | `number` | `8` | no |
 | <a name="input_elb_subnets"></a> [elb\_subnets](#input\_elb\_subnets) | List of subnets where the ELB will be deployed | `list(string)` | `[]` | no |
@@ -143,9 +147,10 @@ No modules.
 | <a name="input_http_endpoint"></a> [http\_endpoint](#input\_http\_endpoint) | Whether the metadata service is available | `bool` | `true` | no |
 | <a name="input_http_put_response_hop_limit"></a> [http\_put\_response\_hop\_limit](#input\_http\_put\_response\_hop\_limit) | The desired HTTP PUT response hop limit for instance metadata requests | `number` | `1` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance size of the bastion | `string` | `"t3.nano"` | no |
-| <a name="input_ipv6_cidrs"></a> [ipv6\_cidrs](#input\_ipv6\_cidrs) | List of IPv6 CIDRs that can access the bastion. Default: ::/0 | `list(string)` | <pre>[<br>  "::/0"<br>]</pre> | no |
+| <a name="input_ipv6_cidrs"></a> [ipv6\_cidrs](#input\_ipv6\_cidrs) | List of IPv6 CIDRs that can access the bastion. Default: ::/0 | `list(string)` | <pre>[<br/>  "::/0"<br/>]</pre> | no |
 | <a name="input_is_lb_private"></a> [is\_lb\_private](#input\_is\_lb\_private) | If TRUE, the load balancer scheme will be "internal" else "internet-facing" | `bool` | `null` | no |
 | <a name="input_kms_enable_key_rotation"></a> [kms\_enable\_key\_rotation](#input\_kms\_enable\_key\_rotation) | Enable key rotation for the KMS key | `bool` | `false` | no |
+| <a name="input_lb_with_security_group"></a> [lb\_with\_security\_group](#input\_lb\_with\_security\_group) | Choose if the LB should have a security group attached. Defaults to false to preserve backwards compatibility. Switching from false to true will recreate the LB. | `bool` | `false` | no |
 | <a name="input_log_auto_clean"></a> [log\_auto\_clean](#input\_log\_auto\_clean) | Enable or disable the lifecycle | `bool` | `false` | no |
 | <a name="input_log_expiry_days"></a> [log\_expiry\_days](#input\_log\_expiry\_days) | Number of days before logs expiration | `number` | `90` | no |
 | <a name="input_log_glacier_days"></a> [log\_glacier\_days](#input\_log\_glacier\_days) | Number of days before moving logs to Glacier | `number` | `60` | no |
@@ -177,11 +182,13 @@ No modules.
 Known issues
 ------------
 
-Tags are not applied to the instances generated by the auto scaling group do to known terraform issue :
+- Tags are not applied to the instances generated by the auto scaling group do to known terraform issue :
 terraform-providers/terraform-provider-aws#290
 
-Change of disk encryption isn't propagate immediately. Change have to trigger manually from AWS CLI:
+- Change of disk encryption isn't propagate immediately. Change have to trigger manually from AWS CLI:
 Auto Scaling Groups -> Instance refresh . Keep in mind all data from instance will be lost in case there are temporary or custom data.
+
+- The AWS provider as of v5.72.1 does not support initial recreation of the NLB if you wish to subsequently add a Security Group via the `lb_with_security_group` variable. It's an uncaught error in the initial terraform apply as the ID of the new security group is not known at the plan stage. A subsequent plan and apply is successful.
 
 Authors
 -------

--- a/locals.tf
+++ b/locals.tf
@@ -7,4 +7,3 @@ locals {
   ipv4_cidr_block = length(compact(data.aws_subnet.subnets[*].cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].cidr_block, var.cidrs)
   ipv6_cidr_block = length(compact(data.aws_subnet.subnets[*].ipv6_cidr_block)) == 0 ? null : concat(data.aws_subnet.subnets[*].ipv6_cidr_block, var.ipv6_cidrs)
 }
-

--- a/main.tf
+++ b/main.tf
@@ -320,7 +320,7 @@ resource "aws_launch_template" "bastion_launch_template" {
 }
 
 resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
-  name_prefix = "ASG-${local.name_prefix}"
+  name_prefix = var.bastion_autoscaling_group_name
   launch_template {
     id      = aws_launch_template.bastion_launch_template.id
     version = aws_launch_template.bastion_launch_template.latest_version
@@ -355,7 +355,7 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
 
   tag {
     key                 = "Name"
-    value               = "ASG-${local.name_prefix}"
+    value               = var.bastion_autoscaling_group_name
     propagate_at_launch = true
   }
 

--- a/user_data.sh
+++ b/user_data.sh
@@ -125,7 +125,7 @@ while read line; do
   USER_NAME="`get_user_name "$line"`"
 
   # Make sure the user name is alphanumeric
-  if [[ "$USER_NAME" =~ ^[a-z][-a-z0-9]*$ ]]; then
+  if [[ "$USER_NAME" =~ ^[a-z][-.a-z0-9]*$ ]]; then
 
     # Create a user account if it does not already exist
     cut -d: -f1 /etc/passwd | grep -qx $USER_NAME

--- a/variables.tf
+++ b/variables.tf
@@ -253,3 +253,9 @@ variable "vpc_id" {
   type        = string
   description = "VPC ID where we'll deploy the bastion"
 }
+
+variable "lb_with_security_group" {
+  type        = bool
+  description = "Choose if the LB should have a security group attached. Defaults to false to preserve backwards compatibility. Switching from false to true will recreate the LB."
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -54,9 +54,15 @@ variable "bastion_instance_count" {
   default = 1
 }
 
+variable "bastion_autoscaling_group_name" {
+  type        = string
+  description = "Bastion Auto scaling group Name"
+  default     = "ASG-bastion-lt"
+}
+
 variable "bastion_launch_template_name" {
   type        = string
-  description = "Bastion Launch template Name, will also be used for the ASG"
+  description = "Bastion Launch template Name"
   default     = "bastion-lt"
 }
 


### PR DESCRIPTION
### Why

Ideally we shouldn't have to manage an ssh key-pair. The private keys are stored in the Terraform state, and seeing as the bastion module provides the ability to create custom users, there should be no need for this now that the module is working.

It's optional, so if required you can always use a key-pair temporarily if you wish.