### PR TITLE
IN-217: Optionally move the Target Group over to a name_prefix to resolve failures when changing the port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ No modules.
 | <a name="input_region"></a> [region](#input\_region) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign | `map(string)` | `{}` | no |
 | <a name="input_use_imds_v2"></a> [use\_imds\_v2](#input\_use\_imds\_v2) | Use (IMDSv2) Instance Metadata Service V2 | `bool` | `false` | no |
+| <a name="input_use_target_group_name_prefix"></a> [use\_target\_group\_name\_prefix](#input\_use\_target\_group\_name\_prefix) | Configure target group 'name\_prefix' instead of 'name'. This resolves issues where, if the `public_ssh_port` changes, another target group cannot be created with the same name. | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where we'll deploy the bastion | `string` | n/a | yes |
 
 ## Outputs

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  name_prefix    = var.bastion_launch_template_name
-  security_group = join("", flatten([aws_security_group.bastion_host_security_group[*].id, var.bastion_security_group_id]))
+  name_prefix       = var.bastion_launch_template_name
+  name_prefix_short = substr(var.bastion_launch_template_name, 0, 6)
+  security_group    = join("", flatten([aws_security_group.bastion_host_security_group[*].id, var.bastion_security_group_id]))
 
   // the compact() function checks for null values and gets rid of them 
   // the length is a check to ensure we dont have an empty array, as an empty array would throw an error for the cidr_block argument 

--- a/main.tf
+++ b/main.tf
@@ -247,7 +247,9 @@ resource "aws_lb" "bastion_lb" {
 resource "aws_lb_target_group" "bastion_lb_target_group" {
   count = var.create_elb ? 1 : 0
 
-  name        = "${local.name_prefix}-lb-target"
+  name        = !var.use_target_group_name_prefix ? "${local.name_prefix}-lb-target" : null
+  name_prefix = var.use_target_group_name_prefix ? local.name_prefix_short : null
+
   port        = var.public_ssh_port
   protocol    = "TCP"
   vpc_id      = var.vpc_id

--- a/variables.tf
+++ b/variables.tf
@@ -306,3 +306,9 @@ variable "bastion_egress_rules_prefix_list" {
   }))
   default = {}
 }
+
+variable "use_target_group_name_prefix" {
+  description = "Configure target group 'name_prefix' instead of 'name'. This resolves issues where, if the `public_ssh_port` changes, another target group cannot be created with the same name."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
### Why

When changing the port on an existing deployment, the terraform apply fails as the name of the Target Group already exists.

Better practice is to use the `name_prefix` argument with a shorter name, and allow terraform to create random suffixes as it does with Auto Scaling groups and Launch Templates.