### PR TITLE
IN-217: Fix the users S3 sync lag by syncing immediately.

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -199,6 +199,11 @@ EOF
 crontab ~/mycron
 rm ~/mycron
 
+###################################
+## SYNC THE S3 USERS IMMEDIATELY ##
+###################################
+
+/usr/bin/bastion/sync_users
 
 #########################################
 ## Add Custom extra_user_data_content ##


### PR DESCRIPTION
### Why

Previously when a new bastion EC2 instance came into service, if you were lucky and the cronjob run immediately, you would be able to SSH. However if you weren't lucky (which is more likely), you'd have to wait up to 5 minutes to SSH, potentially resulting in SSH service downtime for users.