### PR TITLE
Providing empty CIDR rules causes the provider to fail creating the SG rule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_security_group" "lb_security_group" {
 }
 
 resource "aws_security_group_rule" "ingress_lb" {
-  count            = var.lb_with_security_group ? 1 : 0
+  count            = (length(var.cidrs) > 0 || length(var.ipv6_cidrs) > 0) && var.lb_with_security_group ? 1 : 0
   description      = "Incoming traffic to bastion lb"
   type             = "ingress"
   from_port        = var.public_ssh_port


### PR DESCRIPTION
Providing empty CIDR rules causes the provider to fail creating the SG rule

Although cidr_blocks and ipv6_cidr_blocks are all marked as optional, you must provide one of them in order to configure the source of the traffic.

Likewise none must be empty lists.

Taken from:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule

Error we're seeing:

```
module.bastion.aws_security_group_rule.ingress_lb[0]: Still creating... [4m50s elapsed]
module.bastion.aws_security_group_rule.ingress_lb[0]: Still creating... [5m0s elapsed]
Error: waiting for Security Group (sg-0eb68a691820854c6) Rule (sgrule-2909807715) create: couldn't find resource
  with module.bastion.aws_security_group_rule.ingress_lb[0],
  on /tmp/terraform-data-dir/modules/bastion/main.tf line 31, in resource "aws_security_group_rule" "ingress_lb":
  31: resource "aws_security_group_rule" "ingress_lb" {
 ```

With this change, the security rule does not attempt to be created if either list is empty.